### PR TITLE
Explore JSON space usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
   },
   "dependencies": {
     "commander": "^8.1.0",
+    "moo": "^0.5.1",
     "open": "^7.2.1",
     "tmp": "^0.2.1"
   },
   "devDependencies": {
-    "@types/commander": "^2.12.2",
+    "@types/moo": "^0.5.5",
     "@types/node": "^14.6.4",
     "@types/tmp": "^0.2.0",
     "prettier": "1.14.3",
@@ -26,7 +27,8 @@
     "fmt": "prettier --write src/*.ts demo/*.ts *.md",
     "build": "tsc && webpack --mode=production",
     "demo": "du -a node_modules/ | awk '{print $1*512 \"\t\" $2}' | node build/src/cli.js --title 'node_modules for webtreemap'",
-    "demo-tsc": "tsc --listFiles | node build/src/cli.js --title 'tsc --listFiles'"
+    "demo:tsc": "tsc --listFiles | node build/src/cli.js --title 'tsc --listFiles'",
+    "demo:json": "node build/src/cli.js json-space package.json"
   },
   "files": [
     "build/**/*.js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/moo": "^0.5.5",
     "@types/node": "^14.6.4",
     "@types/tmp": "^0.2.0",
-    "prettier": "1.14.3",
+    "prettier": "^2.3.2",
     "typescript": "^4.4.2",
     "webpack": "^5.52.0",
     "webpack-cli": "^4.8.0"
@@ -55,6 +55,7 @@
   "prettier": {
     "singleQuote": true,
     "trailingComma": "es5",
-    "bracketSpacing": false
+    "bracketSpacing": false,
+    "arrowParens": "avoid"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import open from 'open';
 import * as readline from 'readline';
 import * as tmp from 'tmp';
 
-import { processJsonSpaceUsage } from './processors/json';
+import {processJsonSpaceUsage} from './processors/json';
 import * as tree from './tree';
 
 /** Reads stdin into an array of lines. */
@@ -144,8 +144,11 @@ async function main() {
     )
     .option('-o, --output [path]', 'output to file, not stdout')
     .addOption(
-      new Option('-f, --format [format]', 'Set output format')
-        .choices(['html', 'json', 'text'])
+      new Option('-f, --format [format]', 'Set output format').choices([
+        'html',
+        'json',
+        'text',
+      ])
     )
     .option('--title [string]', 'title of output HTML')
     .parse(process.argv);
@@ -157,8 +160,9 @@ async function main() {
     program.args.shift();
   }
 
-  const lines = await
-    (program.args.length > 0 ? readLinesFromFiles(program.args) : readLines());
+  const lines = await (program.args.length > 0
+    ? readLinesFromFiles(program.args)
+    : readLines());
 
   const rows = processor(lines);
   const node = treeFromRows(rows);
@@ -168,12 +172,16 @@ async function main() {
   let outputFormat = args.format as OutputFormat | undefined;
   if (!outputFormat) {
     const output = args.output as string | undefined;
-    outputFormat = output?.endsWith('.json') ? 'json' : output?.endsWith('.txt') ? 'text' : 'html';
+    outputFormat = output?.endsWith('.json')
+      ? 'json'
+      : output?.endsWith('.txt')
+      ? 'text'
+      : 'html';
   }
 
   let output: string;
   if (outputFormat === 'html') {
-  output = `<!doctype html>
+    output = `<!doctype html>
 <title>${title}</title>
 <style>
 html, body {
@@ -211,7 +219,9 @@ render();
   } else if (outputFormat === 'text') {
     output = formatText(node);
   } else {
-    throw new Error(`Unknown output format: ${outputFormat}, expected "html" or "json".`);
+    throw new Error(
+      `Unknown output format: ${outputFormat}, expected "html" or "json".`
+    );
   }
 
   if (args.output) {

--- a/src/processors/json.ts
+++ b/src/processors/json.ts
@@ -1,0 +1,163 @@
+import * as fs from 'fs';
+import moo from 'moo';
+
+declare module 'moo' {
+  // It's convenient to expose this
+  interface Lexer {
+    index: number;
+  }
+}
+
+const symbols = {
+  '{': '{',
+  '}': '}',
+  '[': '[',
+  ']': ']',
+  ',': ',',
+  ':': ':',
+  space: { match: /\s+/, lineBreaks: true },
+  NUMBER: /-?(?:[0-9]|[1-9][0-9]+)(?:\.[0-9]+)?(?:[eE][-+]?[0-9]+)?\b/,
+  STRING: /"(?:\\["bfnrt/\\]|\\u[a-fA-F0-9]{4}|[^"\\])*"/,
+  TRUE: /true\b/,
+  FALSE: /false\b/,
+  NULL: /null\b/,
+} as const;
+
+const lexer = moo.compile(symbols);
+
+interface Segment {
+  key: string;
+  start: number;
+  end?: number;
+}
+
+interface FileSizeMap {
+  [path: string]: number;
+}
+
+const path: Segment[] = [];
+const sizes: FileSizeMap = {};
+
+function pushPath(key: string, pos?: number): void {
+  pos = pos === undefined ? lexer.index : pos;
+  path.push({ key, start: pos });
+}
+
+function popPath(pos?: number): void {
+  const fullPath = path.map(s => s.key).join('/');
+  const x = path.pop();
+  if (!x) {
+    throw new Error('Impossible');
+  }
+  const { start } = x;
+  pos = pos === undefined ? lexer.index : pos;
+  // console.log(`${fullPath}: ${start + 1}-${pos + 1} = ${pos - start + 1}`);
+  sizes[fullPath] = (sizes[fullPath] || 0) + (pos - start + 1);
+}
+
+function addToken(key: string, pos: number, length: number): void {
+  pushPath(key, pos);
+  popPath(pos + length - 1);
+}
+
+function nextSkipWhitepace(lex: moo.Lexer): moo.Token {
+  let tok = lex.next()!;
+  while (tok.type === 'space') {
+    tok = lex.next()!;
+  }
+
+  return tok;
+}
+
+function parseValue(tok: moo.Token, lex: moo.Lexer): void {
+  if (tok.type === '{') {
+    // start object
+    parseObject(lex);
+  } else if (tok.type === '[') {
+    // start array
+    parseArray(lex);
+  } else if (
+    tok.type === 'NUMBER' ||
+    tok.type === 'STRING' ||
+    tok.type === 'TRUE' ||
+    tok.type === 'NULL' ||
+    tok.type === 'FALSE'
+  ) {
+    // no-op
+  } else {
+    throw new Error(`a Unexpected token ${tok.type}`);
+  }
+}
+
+function parseArray(lex: moo.Lexer): void {
+  let tok = nextSkipWhitepace(lex);
+  for (;;) {
+    pushPath('*', tok.offset);
+    parseValue(tok, lex);
+    popPath(lex.index - 1);
+    tok = nextSkipWhitepace(lex);
+    if (tok.type === ']') {
+      break;
+    } else if (tok.type === ',') {
+      tok = nextSkipWhitepace(lex);
+      continue;
+    } else {
+      throw new Error(`b Unexpected token ${tok.type}`);
+    }
+  }
+}
+
+function parseObject(lex: moo.Lexer): void {
+  let tok = nextSkipWhitepace(lex);
+  for (;;) {
+    if (tok.type !== 'STRING') {
+      throw new Error(`c Unexpected token ${tok.type}`);
+    }
+    const key = tok.value.slice(1, -1); // strip quotes
+    addToken('<keys>', tok.offset, tok.text.length);
+    tok = nextSkipWhitepace(lex);
+    if (tok.type !== ':') {
+      throw new Error(`d Unexpected token ${tok.type}`);
+    }
+    tok = nextSkipWhitepace(lex);
+    pushPath(key, tok.offset);
+    parseValue(tok, lex);
+    popPath(lex.index - 1);
+    tok = nextSkipWhitepace(lex);
+    if (tok.type === '}') {
+      break;
+    } else if (tok.type === ',') {
+      tok = nextSkipWhitepace(lex);
+      continue;
+    } else {
+      throw new Error(`e Unexpected token ${tok.type}`);
+    }
+  }
+}
+
+export function leafify(counts: FileSizeMap): FileSizeMap {
+  const childSizes: FileSizeMap = {};
+  for (const [path, count] of Object.entries(counts)) {
+    const parts = path.split('/');
+    if (parts.length > 1) {
+      const parent = parts.slice(0, -1).join('/');
+      childSizes[parent] = (childSizes[parent] || 0) + count;
+    }
+  }
+
+  for (const [path] of Object.entries(counts)) {
+    if (path in childSizes) {
+      const v = childSizes[path];
+      counts[path] -= v;
+    }
+  }
+
+  return counts;
+}
+
+export function processJsonSpaceUsage(lines: readonly string[]): [string, number][] {
+  lexer.reset(lines.join('\n'));
+  parseValue(nextSkipWhitepace(lexer), lexer);
+  leafify(sizes);
+  return Object.entries(sizes);
+}

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -35,7 +35,7 @@ export interface Node {
  * treeify converts an array of [path, size] pairs into a tree.
  * Paths are /-delimited ids.
  */
-export function treeify(data: Array<[string, number]>): Node {
+export function treeify(data: readonly [string, number][]): Node {
   const tree: Node = {size: 0};
   for (const [path, size] of data) {
     const parts = path.replace(/\/$/, '').split('/');

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,13 +7,6 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"
   integrity sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==
 
-"@types/commander@^2.12.2":
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/@types/commander/-/commander-2.12.2.tgz#183041a23842d4281478fa5d23c5ca78e6fd08ae"
-  integrity sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==
-  dependencies:
-    commander "*"
-
 "@types/eslint-scope@^3.7.0":
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.1.tgz#8dc390a7b4f9dd9f1284629efce982e41612116e"
@@ -39,6 +32,11 @@
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
+"@types/moo@^0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@types/moo/-/moo-0.5.5.tgz#83220b7349c59fd4bb1bc14b1d4ea0041899dc15"
+  integrity sha512-eXQpwnkI4Ntw5uJg6i2PINdRFWLr55dqjuYQaLHNjvqTzF14QdNWbCbml9sza0byyXNA0hZlHtcdN+VNDcgVHA==
 
 "@types/node@*":
   version "8.0.40"
@@ -277,11 +275,6 @@ colorette@^1.2.1, colorette@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.3.0.tgz#ff45d2f0edb244069d3b772adeb04fed38d0a0af"
   integrity sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==
-
-commander@*:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz#f8d722b78103141006b66f4c7ba1e97315ba75bc"
-  integrity sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -592,6 +585,11 @@ minimatch@^3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
+
+moo@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
+  integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
 
 neo-async@^2.6.2:
   version "2.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -683,9 +683,10 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prettier@1.14.3:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
+prettier@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 punycode@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
See https://github.com/danvk/source-map-explorer/issues/135

If you run

    treemap json-space /path/to/file.json

Then you'll get a visualization of why your JSON file is so big.

This also adds a `-f` output format specifier. For now it can be `html` (default), `json` or `text` (which can be fed back into the `treemap` command).